### PR TITLE
Update Travis CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,21 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
   - nightly
 
 matrix:
   allow_failures:
     - php: nightly
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - composer self-update


### PR DESCRIPTION
- the PHP 5.3 is available on Precise only
- add PHP 7.2